### PR TITLE
Fix installation command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ We show how to use the body data from AMASS to animate these models.
 
 Clone this repo and run the following from the root folder:
 ```bash
-python install -r requirements.txt
+pip install -r requirements.txt
 python setup.py develop
 ```
 


### PR DESCRIPTION
Minor mistake in the instruction. pip install should be the correct usage.